### PR TITLE
AVRO-3663: [Rust] Allow raw identifiers as field names

### DIFF
--- a/lang/rust/avro_derive/src/lib.rs
+++ b/lang/rust/avro_derive/src/lib.rs
@@ -123,6 +123,9 @@ fn get_data_struct_schema_def(
             let mut index: usize = 0;
             for field in a.named.iter() {
                 let mut name = field.ident.as_ref().unwrap().to_string(); // we know everything has a name
+                if let Some(raw_name) = name.strip_prefix("r#") {
+                    name = raw_name.to_string();
+                }
                 let field_attrs =
                     FieldOptions::from_attributes(&field.attrs[..]).map_err(darling_to_syn)?;
                 let doc = preserve_optional(field_attrs.doc);

--- a/lang/rust/avro_derive/tests/derive.rs
+++ b/lang/rust/avro_derive/tests/derive.rs
@@ -1546,12 +1546,11 @@ mod test_derive {
         });
     }
 
-
     #[test]
-    fn test_avro_3663_raw_identifier_field_name() {     
+    fn test_avro_3663_raw_identifier_field_name() {
         #[derive(Debug, Serialize, Deserialize, AvroSchema, Clone, PartialEq)]
         struct TestRawIdent {
-            r#type: bool
+            r#type: bool,
         }
 
         let derived_schema = TestRawIdent::get_schema();

--- a/lang/rust/avro_derive/tests/derive.rs
+++ b/lang/rust/avro_derive/tests/derive.rs
@@ -1545,4 +1545,21 @@ mod test_derive {
             c: 987.654,
         });
     }
+
+
+    #[test]
+    fn test_raw_identifier_field_name() {     
+        #[derive(Debug, Serialize, Deserialize, AvroSchema, Clone, PartialEq)]
+        struct TestRawIdent {
+            r#type: bool
+        }
+
+        let derived_schema = TestRawIdent::get_schema();
+        if let Schema::Record { fields, .. } = derived_schema {
+            let field = fields.get(0).expect("TestRawIdent must contain a field");
+            assert_eq!(field.name, "type");
+        } else {
+            panic!("Unexpected schema type")
+        }
+    }
 }

--- a/lang/rust/avro_derive/tests/derive.rs
+++ b/lang/rust/avro_derive/tests/derive.rs
@@ -1559,7 +1559,7 @@ mod test_derive {
             let field = fields.get(0).expect("TestRawIdent must contain a field");
             assert_eq!(field.name, "type");
         } else {
-            panic!("Unexpected schema type")
+            panic!("Unexpected schema type for {:?}", derived_schema)
         }
     }
 }

--- a/lang/rust/avro_derive/tests/derive.rs
+++ b/lang/rust/avro_derive/tests/derive.rs
@@ -1548,7 +1548,7 @@ mod test_derive {
 
 
     #[test]
-    fn test_raw_identifier_field_name() {     
+    fn test_avro_3663_raw_identifier_field_name() {     
         #[derive(Debug, Serialize, Deserialize, AvroSchema, Clone, PartialEq)]
         struct TestRawIdent {
             r#type: bool


### PR DESCRIPTION
## What is the purpose of the change

When using a raw identifier as field name, the `r#` prefix was used as field name for the resulting schema which results in an invalid AVRO schema. This fix removes that prefix as it would be expected.

## Verifying this change

This change added tests which can be used to verify the fix.
